### PR TITLE
Add rewrite to serve mockingbird docs from /docs

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -18,6 +18,9 @@ First, run `pnpm i` to install the dependencies.
 
 Then, run `pnpm dev` to start the development server and visit localhost:3000.
 
+> **Warning**
+> During local development the base path is `''` but in production `'/docs'` will be used instead to be able to serve the docs from the mockingbird website under the `/docs` path.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -3,4 +3,6 @@ const withNextra = require('nextra')({
   themeConfig: './theme.config.tsx',
 })
 
-module.exports = withNextra()
+module.exports = withNextra({
+  basePath: process.env.VERCEL_ENV === 'production' ? '/docs' : '',
+})

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/docs',
+        has: [{ type: 'host', value: 'mockingbird.tinybird.co' }],
+        destination: 'https://mockingbird-docs.tinybird.co',
+      },
+      {
+        source: '/docs/:path*',
+        has: [{ type: 'host', value: 'mockingbird.tinybird.co' }],
+        destination: 'https://mockingbird-docs.tinybird.co/:path*',
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
This PR enables a way to serve the `/docs` right from https://mockingbird.tinybird.co/docs.

Note that due it uses a host parameter in the rewrites to prevent problems with static assets during the rewrite, those rewrite rules will only work on production.