### PR TITLE
from URL param

### DIFF
--- a/apps/docs/pages/data_types.md
+++ b/apps/docs/pages/data_types.md
@@ -1,6 +1,6 @@
 # Data Types
 
-You can find the definitions of all Data Types [here](https://github.com/tinybirdco/mockingbird/blob/main/packages/tinybird-generator/src/dataTypes.ts). 
+You can find the definitions of all Data Types [here](https://github.com/tinybirdco/mockingbird/blob/main/packages/tinybird-generator/src/schemaTypes.ts). 
 
 Please feel free to contribute new Data Types!
 

--- a/apps/docs/pages/schemas.md
+++ b/apps/docs/pages/schemas.md
@@ -31,7 +31,7 @@ The output of this schema would look like:
 }
 ```
 
-### Arrays
+## Arrays
 
 All types can be generated as arrays. Simply add a `count` key at the same level as the `type` key.
 
@@ -46,7 +46,9 @@ All types can be generated as arrays. Simply add a `count` key at the same level
 
 ## Preset Schemas
 
-You can write your own custom schema, or use any of the preset schemas.
+You can write your own custom schema, or use any of the preset schemas. 
+
+You can find the definitions of all preset Schemas [here](https://github.com/tinybirdco/mockingbird/blob/main/packages/tinybird-generator/src/presetSchemas.ts). 
 
 Contributions for more preset schemas are welcome!
 

--- a/packages/tinybird-generator/src/generators/TinybirdGenerator.ts
+++ b/packages/tinybird-generator/src/generators/TinybirdGenerator.ts
@@ -129,8 +129,8 @@ export default class TinybirdGenerator extends BaseGenerator<
               (value.count ?? 1) === 1
                 ? value.generator(value.params)
                 : new Array(value.count ?? 1)
-                    .fill(null)
-                    .map(() => value.generator(value.params)),
+                  .fill(null)
+                  .map(() => value.generator(value.params)),
           };
         }, {});
 
@@ -140,7 +140,10 @@ export default class TinybirdGenerator extends BaseGenerator<
   }
 
   async sendData(data: TinybirdMessage[]): Promise<void> {
-    const params = { name: this.config.datasource };
+    const params = {
+      name: this.config.datasource,
+      from: 'mockingbird'
+    };
     const endpointURL =
       this.config.endpoint in this.endpoints
         ? this.endpoints[this.config.endpoint as keyof typeof this.endpoints]


### PR DESCRIPTION
Adds a `from` URL param to the Tinybird generator, so that you can determine which data has been ingested from Mockingbird