### PR TITLE
Update Preview button

### DIFF
--- a/apps/web/src/components/steps/BuildStep.tsx
+++ b/apps/web/src/components/steps/BuildStep.tsx
@@ -119,8 +119,7 @@ export default function BuildStep({ state, dispatch }: BuildStepProps) {
       <div className="flex justify-end gap-6">
         <button
           className={cx(
-            'py-[10px] px-[14px] flex items-center gap-4 bg-tb-primary rounded-[4px] shadow-[0px_1px_3px_rgba(11,19,36,0.1)] text-sm text-white tracking-[-0.01em] hover:scale-105',
-            isSaved && 'bg-opacity-40 cursor-not-allowed'
+            'py-[10px] px-[14px] flex items-center gap-4 bg-tb-primary rounded-[4px] shadow-[0px_1px_3px_rgba(11,19,36,0.1)] text-sm text-white tracking-[-0.01em] hover:scale-105'
           )}
           onClick={() => dispatch({ type: 'setSchema', payload: null })}
         >


### PR DESCRIPTION
Addresses https://github.com/tinybirdco/mockingbird/issues/59 
1. Updates the text on the preview button to Preview rather than Save
2. Removes the 'disable' prop so that you can keep clicking the Preview button to regenerate the preview as much as you like