### PR TITLE
add schema with lat/long data for sports betting

### DIFF
--- a/apps/docs/pages/cli/index.md
+++ b/apps/docs/pages/cli/index.md
@@ -30,7 +30,7 @@ Use `mockingbird-cli <command> --help` to get a list of available options for a 
 --template   Template to use for populating
   [choices: "Simple Example", "eCommerce Transactions", "Stock Prices", "Flight
     Bookings", "Content Tracking", "Web Analytics Starter Kit", "Log Analytics
-                                      Starter Kit"] [default: "Simple Example"]
+                                      Starter Kit", "Sportsbetting"] [default: "Simple Example"]
 --schema     Path to schema file
 --eps        Events per second                                    [default: 1]
 --limit      Max number of rows to send (-1 for unlimited)       [default: -1]

--- a/apps/docs/pages/schemas.md
+++ b/apps/docs/pages/schemas.md
@@ -88,3 +88,7 @@ The `Log Analytics Starter Kit` allows you to generate mock data for the [Tinybi
 ### Flappybird
 
 The `Flappybird` schema is an example of a stream of game events.
+
+### Sportsbetting
+
+The `Sportsbetting` schema is an example of a stream of Sportsbetting location events.

--- a/packages/mockingbird/src/presetSchemas.ts
+++ b/packages/mockingbird/src/presetSchemas.ts
@@ -811,6 +811,24 @@ const presetSchemas: Record<PresetSchemaName, Schema> = {
         }
       ]
     }
+  },
+  "Sportsbetting": {
+    timestamp: {
+      type: "mockingbird.timestampNow"
+    },
+    location: {
+      type: "location.nearbyGPSCoordinate",
+      params: [
+        {
+          isMetric: true,
+          radius: 5,
+          origin : [35.225808,-80.852861]
+        }
+      ]
+    },
+    userEmail: {
+      type: "internet.email"
+    }
   }
 };
 

--- a/packages/mockingbird/src/types.ts
+++ b/packages/mockingbird/src/types.ts
@@ -101,7 +101,8 @@ export const PRESET_SCHEMA_NAMES = [
   "Content Tracking",
   "Web Analytics Starter Kit",
   "Log Analytics Starter Kit",
-  "Flappybird"
+  "Flappybird",
+  "Sportsbetting"
 ] as const;
 export type PresetSchemaName = (typeof PRESET_SCHEMA_NAMES)[number];
 


### PR DESCRIPTION
Add a new default schema with a timestamp, user email, and random lat/long location near a sports stadium.
This is useful for demonstrating how a data scientist can work with location data in Tinybird or other stream processing.