### PR TITLE
April Mockingbird patch

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
-    "@tinybirdco/mockingbird": "^1.1.3",
+    "@tinybirdco/mockingbird": "^1.2.0",
     "@types/node": "20.6.2",
     "@types/react": "18.2.22",
     "@types/react-dom": "18.2.7",

--- a/apps/web/src/components/settings/TinybirdSettings.tsx
+++ b/apps/web/src/components/settings/TinybirdSettings.tsx
@@ -3,20 +3,20 @@ import { useState } from 'react'
 import { MockingbirdConfig } from '@/lib/constants'
 
 enum HostType {
-  EU_GCP = 'eu_gcp',
-  US_GCP = 'us_gcp',
-  EU_AWS_CENTRAL_1 = 'eu_central_1_aws',
-  US_AWS_EAST_1 = 'us_east_1_aws',
-  US_AWS_WEST_2 = 'us_west_2_aws',
+  GCP_EU_WEST3 = 'gcp_europe-west3',
+  GCP_US_EAST4 = 'gcp_us-east4',
+  AWS_EU_CENTRAL_1 = 'aws_eu_central_1',
+  AWS_US_EAST_1 = 'aws_us_east_1',
+  AWS_US_WEST_2 = 'aws_us_west_2',
   Custom = 'custom',
 }
 
 const ENDPOINT_OPTIONS = [
-  { label: 'EU (GCP)', value: HostType.EU_GCP },
-  { label: 'US (GCP)', value: HostType.US_GCP },
-  { label: 'EU (AWS)', value: HostType.EU_AWS_CENTRAL_1 },
-  { label: 'US EAST (AWS)', value: HostType.US_AWS_EAST_1},
-  { label: 'US WEST (AWS)', value: HostType.US_AWS_WEST_2},
+  { label: 'GCP europe-west3', value: HostType.GCP_EU_WEST3 },
+  { label: 'GCP us-east4', value: HostType.GCP_US_EAST4 },
+  { label: 'AWS eu-central-1', value: HostType.AWS_EU_CENTRAL_1 },
+  { label: 'AWS us-east-1', value: HostType.AWS_US_EAST_1},
+  { label: 'AWS us-west-2', value: HostType.AWS_US_WEST_2},
   { label: 'Custom', value: HostType.Custom },
 ] as const
 

--- a/apps/web/src/components/settings/TinybirdSettings.tsx
+++ b/apps/web/src/components/settings/TinybirdSettings.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react'
 import { MockingbirdConfig } from '@/lib/constants'
 
 enum HostType {
-  GCP_EU_WEST3 = 'gcp_europe-west3',
-  GCP_US_EAST4 = 'gcp_us-east4',
+  GCP_EU_WEST3 = 'gcp_europe_west3',
+  GCP_US_EAST4 = 'gcp_us_east4',
   AWS_EU_CENTRAL_1 = 'aws_eu_central_1',
   AWS_US_EAST_1 = 'aws_us_east_1',
   AWS_US_WEST_2 = 'aws_us_west_2',

--- a/apps/web/src/components/settings/TinybirdSettings.tsx
+++ b/apps/web/src/components/settings/TinybirdSettings.tsx
@@ -5,9 +5,9 @@ import { MockingbirdConfig } from '@/lib/constants'
 enum HostType {
   EU_GCP = 'eu_gcp',
   US_GCP = 'us_gcp',
-  EU_AWS_CENTRAL_1 = 'eu_aws_central_1',
-  US_AWS_EAST_1 = 'us_aws_east_1',
-  US_AWS_WEST_2 = 'us_aws_east_2',
+  EU_AWS_CENTRAL_1 = 'eu_central_1_aws',
+  US_AWS_EAST_1 = 'us_east_1_aws',
+  US_AWS_WEST_2 = 'us_west_2_aws',
   Custom = 'custom',
 }
 

--- a/apps/web/src/components/settings/TinybirdSettings.tsx
+++ b/apps/web/src/components/settings/TinybirdSettings.tsx
@@ -30,7 +30,7 @@ export default function TinybirdSettings({ config }: TinybirdSettingsProps) {
   const datasource =
     config && 'datasource' in config ? config.datasource : undefined
   const defaultHost =
-    ENDPOINT_OPTIONS.find(ep => ep.value === endpoint)?.value ?? HostType.EU_GCP
+    ENDPOINT_OPTIONS.find(ep => ep.value === endpoint)?.value ?? HostType.GCP_EU_WEST3
 
   const [selectedHost, setSelectedHost] = useState<HostType>(defaultHost)
 

--- a/apps/web/src/components/settings/TinybirdSettings.tsx
+++ b/apps/web/src/components/settings/TinybirdSettings.tsx
@@ -5,12 +5,18 @@ import { MockingbirdConfig } from '@/lib/constants'
 enum HostType {
   EU_GCP = 'eu_gcp',
   US_GCP = 'us_gcp',
+  EU_AWS_CENTRAL_1 = 'eu_aws_central_1',
+  US_AWS_EAST_1 = 'us_aws_east_1',
+  US_AWS_WEST_2 = 'us_aws_east_2',
   Custom = 'custom',
 }
 
 const ENDPOINT_OPTIONS = [
   { label: 'EU (GCP)', value: HostType.EU_GCP },
   { label: 'US (GCP)', value: HostType.US_GCP },
+  { label: 'EU (AWS)', value: HostType.EU_AWS_CENTRAL_1 },
+  { label: 'US EAST (AWS)', value: HostType.US_AWS_EAST_1},
+  { label: 'US WEST (AWS)', value: HostType.US_AWS_WEST_2},
   { label: 'Custom', value: HostType.Custom },
 ] as const
 

--- a/apps/web/src/components/settings/TinybirdSettings.tsx
+++ b/apps/web/src/components/settings/TinybirdSettings.tsx
@@ -53,7 +53,7 @@ export default function TinybirdSettings({ config }: TinybirdSettingsProps) {
 
       <div className="h-6" />
 
-      <div className="grid lg:grid-cols-[140px_288px_auto] gap-6">
+      <div className="grid lg:grid-cols-[180px_248px_auto] gap-6">
         <div className="flex flex-col gap-1">
           <label htmlFor="host" className="text-sm text-tb-text1">
             Host

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
-        "@tinybirdco/mockingbird": "^1.1.3",
+        "@tinybirdco/mockingbird": "^1.2.0",
         "@types/node": "20.6.2",
         "@types/react": "18.2.22",
         "@types/react-dom": "18.2.7",
@@ -71,6 +71,21 @@
         "tailwindcss": "^3.3.3"
       }
     },
+    "apps/web/node_modules/@tinybirdco/mockingbird": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tinybirdco/mockingbird/-/mockingbird-1.2.0.tgz",
+      "integrity": "sha512-vd57TVDnvHzn6mumFTTH3YjGMdDdegzwwacnoStTWXqZ14ClIOzyx5alZv0MPYXrLMM0+2nV31MkIStVcMaDgQ==",
+      "dependencies": {
+        "@aws-sdk/client-sns": "^3.414.0",
+        "@faker-js/faker": "^8.0.2",
+        "amqplib": "^0.10.3",
+        "cross-fetch": "^4.0.0",
+        "lodash.get": "^4.4.2",
+        "ts-json-schema-generator": "^1.3.0",
+        "ts-morph": "^19.0.0",
+        "zod": "^3.22.2"
+      }
+    },
     "apps/web/node_modules/@types/node": {
       "version": "20.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.2.tgz",
@@ -86,6 +101,14 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "apps/web/node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/packages/mockingbird/src/generators/TinybirdGenerator.ts
+++ b/packages/mockingbird/src/generators/TinybirdGenerator.ts
@@ -18,6 +18,9 @@ export default class TinybirdGenerator extends BaseGenerator<TinybirdConfig> {
   readonly endpoints = {
     eu_gcp: "https://api.tinybird.co",
     us_gcp: "https://api.us-east.tinybird.co",
+    us_east_1_aws: "https://api.us-east.aws.tinybird.co",
+    eu_central_1_aws: "https://api.eu-central-1.aws.tinybird.co"
+    us_west_2_aws: "https://api.us-west-2.aws.tinybird.co"
   } as const;
 
   readonly events_path = "/v0/events" as const;

--- a/packages/mockingbird/src/generators/TinybirdGenerator.ts
+++ b/packages/mockingbird/src/generators/TinybirdGenerator.ts
@@ -16,11 +16,8 @@ export type TinybirdConfig = z.infer<typeof tinybirdConfigSchema>;
 
 export default class TinybirdGenerator extends BaseGenerator<TinybirdConfig> {
   readonly endpoints = {
-    gcp_europe_west3: "https://api.tinybird.co",
-    gcp_us_east4': "https://api.us-east.tinybird.co",
-    aws_us_east_1: "https://api.us-east.aws.tinybird.co",
-    aws_eu_central_1: "https://api.eu-central-1.aws.tinybird.co",
-    aws_us_west_2: "https://api.us-west-2.aws.tinybird.co"
+    eu_gcp: "https://api.tinybird.co",
+    us_gcp: "https://api.us-east.tinybird.co",
   } as const;
 
   readonly events_path = "/v0/events" as const;

--- a/packages/mockingbird/src/generators/TinybirdGenerator.ts
+++ b/packages/mockingbird/src/generators/TinybirdGenerator.ts
@@ -16,11 +16,11 @@ export type TinybirdConfig = z.infer<typeof tinybirdConfigSchema>;
 
 export default class TinybirdGenerator extends BaseGenerator<TinybirdConfig> {
   readonly endpoints = {
-    eu_gcp: "https://api.tinybird.co",
-    us_gcp: "https://api.us-east.tinybird.co",
-    us_east_1_aws: "https://api.us-east.aws.tinybird.co",
-    eu_central_1_aws: "https://api.eu-central-1.aws.tinybird.co",
-    us_west_2_aws: "https://api.us-west-2.aws.tinybird.co"
+    gcp_europe_west3: "https://api.tinybird.co",
+    gcp_us_east4': "https://api.us-east.tinybird.co",
+    aws_us_east_1: "https://api.us-east.aws.tinybird.co",
+    aws_eu_central_1: "https://api.eu-central-1.aws.tinybird.co",
+    aws_us_west_2: "https://api.us-west-2.aws.tinybird.co"
   } as const;
 
   readonly events_path = "/v0/events" as const;

--- a/packages/mockingbird/src/generators/TinybirdGenerator.ts
+++ b/packages/mockingbird/src/generators/TinybirdGenerator.ts
@@ -19,7 +19,7 @@ export default class TinybirdGenerator extends BaseGenerator<TinybirdConfig> {
     eu_gcp: "https://api.tinybird.co",
     us_gcp: "https://api.us-east.tinybird.co",
     us_east_1_aws: "https://api.us-east.aws.tinybird.co",
-    eu_central_1_aws: "https://api.eu-central-1.aws.tinybird.co"
+    eu_central_1_aws: "https://api.eu-central-1.aws.tinybird.co",
     us_west_2_aws: "https://api.us-west-2.aws.tinybird.co"
   } as const;
 


### PR DESCRIPTION
Add AWS regions to Host dropdown for Mockingbird Tinybird Events API Settings to eliminate need to specify Endpoint with Custom.

https://www.tinybird.co/docs/api-reference/overview#regions-and-endpoints
<img width="800" alt="Screenshot 2024-08-01 at 17 50 13" src="https://github.com/user-attachments/assets/5ebd90de-c6bf-47b2-9466-be8c1e01fb6a">
