### PR TITLE
update endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9901,7 +9901,7 @@
     },
     "packages/mockingbird": {
       "name": "@tinybirdco/mockingbird",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "dependencies": {
         "@aws-sdk/client-sns": "^3.414.0",
         "@faker-js/faker": "^8.0.2",

--- a/packages/mockingbird/package.json
+++ b/packages/mockingbird/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tinybirdco/mockingbird",
   "description": "Mockingbird",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mockingbird/src/generators/TinybirdGenerator.ts
+++ b/packages/mockingbird/src/generators/TinybirdGenerator.ts
@@ -16,8 +16,11 @@ export type TinybirdConfig = z.infer<typeof tinybirdConfigSchema>;
 
 export default class TinybirdGenerator extends BaseGenerator<TinybirdConfig> {
   readonly endpoints = {
-    eu_gcp: "https://api.tinybird.co",
-    us_gcp: "https://api.us-east.tinybird.co",
+    gcp_europe_west3: "https://api.tinybird.co",
+    gcp_us_east4: "https://api.us-east.tinybird.co",
+    aws_us_east_1: "https://api.us-east.aws.tinybird.co",
+    aws_eu_central_1: "https://api.eu-central-1.aws.tinybird.co",
+    aws_us_west_2: "https://api.us-west-2.aws.tinybird.co"
   } as const;
 
   readonly events_path = "/v0/events" as const;


### PR DESCRIPTION
splits the package updates out from https://github.com/tinybirdco/mockingbird/pull/86 

bumps package ver to 1.2