### PR TITLE
Updated cli to use new tinybird endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you need help with defining schemas, or configuring particular Destinations, 
 
 ### Passing params in the URL
 
-If you want to re-use configurations from a previous session, you can simply save the URL. All settings are saved as parameters in the URL, so you can re-use and share configs with your team. For example: [http://localhost:3000/?schema=z_sales&eps=1&host=eu_gcp&datasource=sales_dg&token=p.eyJ1IjogIjg4Nzk5NGUxLWZmNmMtNGUyMi1iZTg5LTNlYzBmNmRmMzlkZCIsICJpZCI6ICIwN2RlZThhMS0wNGMzLTQ4OTQtYmQxNi05ZTlkMmM3ZWRhMTgifQ.p_N4EETK7dbxOgHtugAUue3BUWwyGHT461Ha8P-d3Go](http://localhost:3000/?schema=z_sales&eps=1&host=eu_gcp&datasource=sales_dg&token=p.eyJ1IjogIjg4Nzk5NGUxLWZmNmMtNGUyMi1iZTg5LTNlYzBmNmRmMzlkZCIsICJpZCI6ICIwN2RlZThhMS0wNGMzLTQ4OTQtYmQxNi05ZTlkMmM3ZWRhMTgifQ.p_N4EETK7dbxOgHtugAUue3BUWwyGHT461Ha8P-d3Go)
+If you want to re-use configurations from a previous session, you can simply save the URL. All settings are saved as parameters in the URL, so you can re-use and share configs with your team. For example: [http://localhost:3000/?schema=z_sales&eps=1&host=gcp_europe_west3&datasource=sales_dg&token=p.eyJ1IjogIjg4Nzk5NGUxLWZmNmMtNGUyMi1iZTg5LTNlYzBmNmRmMzlkZCIsICJpZCI6ICIwN2RlZThhMS0wNGMzLTQ4OTQtYmQxNi05ZTlkMmM3ZWRhMTgifQ.p_N4EETK7dbxOgHtugAUue3BUWwyGHT461Ha8P-d3Go](http://localhost:3000/?schema=z_sales&eps=1&host=gcp_europe_west3&datasource=sales_dg&token=p.eyJ1IjogIjg4Nzk5NGUxLWZmNmMtNGUyMi1iZTg5LTNlYzBmNmRmMzlkZCIsICJpZCI6ICIwN2RlZThhMS0wNGMzLTQ4OTQtYmQxNi05ZTlkMmM3ZWRhMTgifQ.p_N4EETK7dbxOgHtugAUue3BUWwyGHT461Ha8P-d3Go)
 
 **Warning**: all settings are saved in the URL including senstive field such as tokens & passwords! This is helpful in many occasions for demos, POCs and tests where these credentials are short-lived and disposable - but take care if you are using credentials that must not be shared!
 
@@ -45,7 +45,7 @@ Here is an example of sending data to the Tinybird Events API:
   --schema schema.json \
   --datasource "my_data_source" \
   --token "e.Pdjdbfsbhksd...." \
-  --endpoint eu_gcp \
+  --endpoint gcp_europe_west3 \
   --eps 50 \
   --limit 200
 ```

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -79,7 +79,7 @@ Use `mockingbird-cli <command> --help` to get a list of available options for a 
 
 ```bash
 --endpoint    API endpoint name
-                            [required] [choices: "eu_gcp", "us_gcp", "custom"]
+                            [required] [choices: "gcp_europe_west3", "gcp_us_east4", "aws_eu_central_1", "aws_us_east_1", "aws_us_west_2", "custom"]
 --datasource  Datasource name                                       [required]
 --token       API token                                             [required]
 ```

--- a/apps/cli/subcommands.js
+++ b/apps/cli/subcommands.js
@@ -139,7 +139,7 @@ export const subcommands = [
     options: {
       endpoint: {
         describe: "API endpoint name",
-        choices: ["eu_gcp", "us_gcp", "custom"],
+        choices: ["eu_gcp", "us_gcp", "gcp_europe_west3", "gcp_us_east4", "aws_eu_central_1", "aws_us_east_1", "aws_us_west_2", "custom"],
         demandOption: true,
       },
       datasource: {
@@ -149,11 +149,20 @@ export const subcommands = [
       token: { describe: "API token", demandOption: true },
     },
     middlewares: [
-      (argv) => ({
-        endpoint: ["eu_gcp", "us_gcp"].includes(argv.endpoint)
-          ? argv.endpoint
-          : process.env.TB_ENDPOINT,
-      }),
+      (argv) => {
+        if (argv.endpoint === 'eu_gcp') {
+          console.error('eu_gcp is deprecated, use gcp_europe_west3 instead');
+          process.exit(1);
+        } else if (argv.endpoint === 'us_gcp') {
+          console.error('us_gcp is deprecated, use gcp_us_east4 instead');
+          process.exit(1);
+        } else if (argv.endpoint === 'custom' && !process.env.TB_ENDPOINT) {
+          console.error('process.env.TB_ENDPOINT must be set when endpoint is set to "custom"');
+          process.exit(1);
+        }
+
+        return argv.endpoint === 'custom' ? process.env.TB_ENDPOINT : argv.endpoint;
+      },
     ],
   },
   {

--- a/apps/docs/pages/cli/index.md
+++ b/apps/docs/pages/cli/index.md
@@ -71,7 +71,7 @@ Use `mockingbird-cli <command> --help` to get a list of available options for a 
 
 ```bash
 --endpoint    API endpoint name
-                            [required] [choices: "eu_gcp", "us_gcp", "custom"]
+                            [required] [choices: "gcp_europe_west3", "gcp_us_east4", "aws_eu_central_1", "aws_us_east_1", "aws_us_west_2", "custom"]
 --datasource  Datasource name                                       [required]
 --token       API token                                             [required]
 ```
@@ -90,5 +90,5 @@ Use `mockingbird-cli <command> --help` to get a list of available options for a 
 As an example, to send data to Tinybird, in the EU region, using the `Stock Prices` template, to a Data Source called `stocks`, at 100 Events Per Second:
 
 ```bash
-mockingbird-cli tinybird --datasource=stocks --token=e.pXXX --endpoint=eu_gcp --template "Stock Prices" --eps 100
+mockingbird-cli tinybird --datasource=stocks --token=e.pXXX --endpoint=gcp_europe_west3 --template "Stock Prices" --eps 100
 ```

--- a/apps/docs/pages/library/index.md
+++ b/apps/docs/pages/library/index.md
@@ -18,7 +18,6 @@ The most basic usage is to import one of the generators, initialize it and call 
 import {
   presetSchemas,
   TinybirdGenerator,
-  ALL_TINYBIRD_ENDPOINTS,
   generate,
 } from "@tinybirdco/mockingbird";
 
@@ -26,7 +25,7 @@ const schema = presetSchemas["Simple Example"];
 
 const tbGenerator = new TinybirdGenerator({
   schema,
-  endpoint: "eu_gcp",
+  endpoint: "gcp_europe_west3",
   datasource: "test",
   token: "e.pXXXX",
   eps: 100,

--- a/packages/mockingbird/README.md
+++ b/packages/mockingbird/README.md
@@ -23,7 +23,7 @@ const tbGenerator = new TinybirdGenerator({
   eps: z.number().optional().default(1), // Events per second
   limit: z.number().optional().default(-1), // Event limit
   logs: z.boolean().optional().default(false), // Enables logs
-  endpoint: z.string(), // Tinybird endpoint (eu_gcp, us_gcp or custom one)
+  endpoint: z.string(), // Tinybird endpoint (e.g. gcp_europe_west3, gcp_us_east4, aws_eu_central_1, aws_us_east_1, aws_us_west_2 or custom one)
   datasource: z.string(), // Name of the Tinybird datasource
   token: z.string(), // Tinybird admin token
 });


### PR DESCRIPTION
I've been following along with https://www.tinybird.co/docs/guides/tutorials/user-facing-web-analytics#2-stream-mock-data-to-your-data-source and a bunch of other tutorials and guides from Tinybird, and got stuck trying to use the mockingbird CLI

(Actually, I got stuck trying to use the UI first, not sure why that wasn't working).

Anyhow - I figured out the cli wants me to use `eu_gcp` but the generator expects `gcp_europe_west3`. I tried to work around it by using `custom`, but I ended up having to read the code to figure out that I needed to set TB_ENDPOINT.

As a result, this PR includes both an improvement (throwing a clear error when using custom and TB_ENDPOINT isn't set) and fixes for the updated names of the endpoints.

I've updated everywhere I could find the outdated names.

I also made it so that the CLI will error clearly (no stack trace) when using the outdated eu_gcp and us_gcp names.

Finally, I removed the `ALL_TINYBIRD_ENDPOINTS,` from the library docs as that constant no longer exists.

Please let me know if you'd prefer any of this separated out or would prefer a different pattern.


---

refs: https://github.com/tinybirdco/mockingbird/pull/86

- This is a followup to previous work done to the generators and web app to support the diversification of endpoints on tinybird
- I've followed the naming convention, switching eu_gcp to gcp_europe_west3 everywhere
- This will also require documentation updates, but in the meantime, the CLI tool will throw a helpful error if you get it wrong
- Also improved the CLI to return a helpful error if you set the endpoint to custom and don't have process.env.TB_ENDPOINT set, which is a problem I ran into whilst attempting to workaround the endpoint name changes